### PR TITLE
HMAC based One Time Password

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 OpenVPN OTP Authentication support
 ==================================
 
-This plug-in adds support for OTP time based tokens for OpenVPN.
-Compatible with Google Authenticator software token, other software and hardware based OTP time tokens.
+This plug-in adds support for time based OTP (totp) and HMAC based OTP (hotp) tokens for OpenVPN.
+Compatible with Google Authenticator software token, other software and hardware based OTP tokens.
 
 Compile and install openvpn-otp.so file to your OpenVPN plugins directory (usually /usr/lib/openvpn or /usr/lib64/openvpn/plugins).
 
@@ -33,6 +33,8 @@ By default the following settings are applied:
     totp_step=30                          # Step value for TOTP (seconds)
     totp_digits=6                         # Number of digits to use from TOTP hash
     motp_step=10                          # Step value for MOTP
+    hotp_syncwindow=2                     # Maximum drifts allowed for clients to resynchronise their tokens counters (see rfc4226#section-7.4)
+    hotp_counters=/var/share/openvpn/hotp-counters/      # HOTP counters directory
 
 Add these variables on the same line as **plugin /.../openvpn-otp.so** line if you want different values.
 If you skip one of the variables, the default value will be applied.
@@ -71,6 +73,9 @@ The otp-secrets file format is exactly the same as for ppp-otp plugin, which mak
     # use sha1/base32 for Google Authenticator without a pin
     john otp totp:sha1:base32:LJYHR64TUI7IL3RD::xxx *
 
+    # use sha1/base32 for HOTP without a pin
+    lucie otp hotp:sha1:base32::MT4GWEZTSRBV2QQC:xxx *
+
     # use totp-60-6 and sha1/hex for hardware based 60 seconds / 6 digits tokens
     mike otp totp-60-6:sha1:hex:5c5a75a87ba1b48cb0b6adfd3b7a5a0e:6543:xxx *
     
@@ -93,6 +98,30 @@ password: 5uP3rH4x0r797104
 username: john
 password: 408923
 ```
+
+
+
+Initiate HOTP counters
+======================
+
+HOTP counters are stored in files, which resides under the
+``hotp-counters`` directory (``/var/cache/openvpn/hotp-counters/`` by
+default).
+
+For each HOTP entry in the ``otp-secrets`` files, we compute the sha1
+checksum of the secret key, and we use the result as the filename.
+
+For example, the counter for the
+``hotp:sha1:base32:GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ::xxx`` entry will
+be read and stored in
+``/var/cache/openvpn/hotp-counters/7C222FB2927D828AF22F592134E8932480637C0D``.
+
+To allow the usage of one HTOP, the administrator is expected to
+populate the file in which the counter is stored. The following
+command will do the job :
+
+        echo -n 10 > /var/cache/openvpn/hotp-counters/"$(echo -n 'secretkey' | sha1sum | cut -f1 -d ' ')"
+
 
 SELinux
 ===============

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Initiate HOTP counters
 ======================
 
 HOTP counters are stored in files, which resides under the
-``hotp-counters`` directory (``/var/cache/openvpn/hotp-counters/`` by
+``hotp-counters`` directory (``/var/spool/openvpn/hotp-counters/`` by
 default).
 
 For each HOTP entry in the ``otp-secrets`` files, we compute the sha1
@@ -114,13 +114,13 @@ checksum of the secret key, and we use the result as the filename.
 For example, the counter for the
 ``hotp:sha1:base32:GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ::xxx`` entry will
 be read and stored in
-``/var/cache/openvpn/hotp-counters/7C222FB2927D828AF22F592134E8932480637C0D``.
+``/var/spool/openvpn/hotp-counters/7C222FB2927D828AF22F592134E8932480637C0D``.
 
 To allow the usage of one HTOP, the administrator is expected to
 populate the file in which the counter is stored. The following
 command will do the job :
 
-        echo -n 10 > /var/cache/openvpn/hotp-counters/"$(echo -n 'secretkey' | sha1sum | cut -f1 -d ' ')"
+        echo -n 10 > /var/spool/openvpn/hotp-counters/"$(echo -n 'secretkey' | sha1sum | cut -f1 -d ' ')"
 
 
 SELinux

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ The otp-secrets file format is exactly the same as for ppp-otp plugin, which mak
     
     # use text encoding for clients supporting plain text keys
     jane otp totp:sha1:text:1234567890:9876:xxx *
+
+    # allow multiple tokens for a specific user
+    hobbes otp totp:sha1:base32:LJYHR64TUI7IL3RD::xxx *
+    hobbes otp totp:sha1:base32:7VXNJAFPYYKO3ILO::xxx *
     
 When users vpn in, they will need to provide their username and pin+current OTP number from the OTP token. Examples for users bob, alice and john:
 

--- a/src/otp.c
+++ b/src/otp.c
@@ -286,20 +286,20 @@ static int otp_verify(const char *vpn_username, const char *vpn_secret)
         const void * otp_key;
     
         if (!strcasecmp(otp_params.encoding, "base32")) {
-            key_len = base32_decode((uint8_t *) otp_params.key, decoded_secret, sizeof(decoded_secret)); 
+            key_len = base32_decode((uint8_t *) otp_params.key, decoded_secret, sizeof(decoded_secret));
             otp_key = decoded_secret;
         } else
-            if (!strcasecmp(otp_params.encoding, "hex")) {
-                key_len = hex_decode(otp_params.key, decoded_secret, sizeof(decoded_secret));
-                otp_key = decoded_secret;
-            } else
-                if (!strcasecmp(otp_params.encoding, "text")) {
-                    otp_key = otp_params.key;
-                    key_len = strlen(otp_params.key);
-                } else {
-                    LOG("OTP-AUTH: unknown encoding '%s'\n", otp_params.encoding);
-                    goto done;
-                }
+        if (!strcasecmp(otp_params.encoding, "hex")) {
+            key_len = hex_decode(otp_params.key, decoded_secret, sizeof(decoded_secret));
+            otp_key = decoded_secret;
+        } else
+        if (!strcasecmp(otp_params.encoding, "text")) {
+            otp_key = otp_params.key;
+            key_len = strlen(otp_params.key);
+        } else {
+            LOG("OTP-AUTH: unknown encoding '%s'\n", otp_params.encoding);
+            goto done;
+        }
     
         uint64_t T, Tn;
         uint8_t mac[EVP_MAX_MD_SIZE];

--- a/src/otp.c
+++ b/src/otp.c
@@ -21,7 +21,7 @@
 
 
 static char *otp_secrets = "/etc/ppp/otp-secrets";
-static char *hotp_counters = "/var/cache/openvpn/hotp-counters/";
+static char *hotp_counters = "/var/spool/openvpn/hotp-counters/";
 static int otp_slop = 180;
 
 static int totp_t0 = 0;

--- a/src/otp.c
+++ b/src/otp.c
@@ -248,7 +248,7 @@ hotp_read_counter(const void * otp_key){
     SHA1(otp_key, sizeof(otp_key), hash);
 
     for (i = 0; i < 20; i++) {
-        sprintf(&hexdigest[i*2], "%02X", hash[i]);
+        sprintf(&hexdigest[i*2], "%02x", hash[i]);
     }
     snprintf(path, sizeof(path), "%s%s", hotp_counters, hexdigest);
     /* Find matching SHA1*/

--- a/src/otp.c
+++ b/src/otp.c
@@ -249,14 +249,13 @@ hotp_read_counter(const void * otp_key){
         sprintf(&hexdigest[i*2], "%02X", hash[i]);
     }
     snprintf(path, sizeof(path), "%s%s", hotp_counters, hexdigest);
-    LOG("Lookup file %s\n", path);
     /* Find matching SHA1*/
     counter_file = fopen(path, "r");
     if (counter_file != NULL && fgets(line, sizeof(line), counter_file)){
         fclose(counter_file);
         return atoi(line);
     }
-    LOG("Hash not found !\n");
+    LOG("OTP-AUTH: HTOP Hash %s counter file not found !\n", hexdigest);
     /* Read current counter value*/
     return -1;
 }
@@ -277,14 +276,14 @@ hotp_set_counter(const void * otp_key, int counter){
         sprintf(&hexdigest[i*2], "%02X", hash[i]);
     }
     snprintf(path, sizeof(path), "%s%s", hotp_counters, hexdigest);
-    LOG("Lookup file %s\n", path);
+
     /* Find matching SHA1*/
     counter_file = fopen(path, "w");
     if (counter_file != NULL && fprintf(counter_file, "%d", counter)){
         fclose(counter_file);
         return 0;
     }
-    LOG("Hash not found !\n");
+    LOG("OTP-AUTH: HTOP Hash %s counter file not found !\n", hexdigest);
     /* Read current counter value*/
     return -1;
 }
@@ -427,7 +426,6 @@ static int otp_verify(const char *vpn_username, const char *vpn_secret)
             otp %= divisor;
 
             snprintf(secret, sizeof(secret), "%s%0*u", otp_params.pin, tdigits, otp);
-            LOG("Computed htop : %s\n", secret);
             if (vpn_username && !strcmp (vpn_username, user_entry.name)
                 && vpn_secret && !strcmp (vpn_secret, secret)) {
                 ok = 1;

--- a/src/otp.c
+++ b/src/otp.c
@@ -245,7 +245,7 @@ hotp_read_counter(const void * otp_key){
     FILE *counter_file;
     int i;
 
-    SHA1(otp_key, sizeof(otp_key), hash);
+    SHA1(otp_key, strlen(otp_key), hash);
 
     for (i = 0; i < 20; i++) {
         sprintf(&hexdigest[i*2], "%02x", hash[i]);
@@ -272,7 +272,7 @@ hotp_set_counter(const void * otp_key, int counter){
     FILE *counter_file;
     int i;
 
-    SHA1(otp_key, sizeof(otp_key), hash);
+    SHA1(otp_key, strlen(otp_key), hash);
 
     for (i = 0; i < 20; i++) {
         sprintf(&hexdigest[i*2], "%02X", hash[i]);
@@ -410,7 +410,7 @@ static int otp_verify(const char *vpn_username, const char *vpn_secret)
             int tdigits = totp_digits;
             int i = 0;
 
-            T = hotp_read_counter(otp_key);
+            T = hotp_read_counter(otp_params.key);
 
             for (i = 0; i < tdigits; ++i) {
                 divisor *= 10;
@@ -433,7 +433,7 @@ static int otp_verify(const char *vpn_username, const char *vpn_secret)
                 if (vpn_username && !strcmp (vpn_username, user_entry.name)
                     && vpn_secret && !strcmp (vpn_secret, secret)) {
                     ok = 1;
-                    hotp_set_counter(otp_key, T-i-1);
+                    hotp_set_counter(otp_params.key, T-i-1);
                 }
             }
         }

--- a/src/otp.c
+++ b/src/otp.c
@@ -262,129 +262,128 @@ static int otp_verify(const char *vpn_username, const char *vpn_secret)
             continue;
         }
 
-        break;
-    }
-
-    /* Handle non-otp passwords before trying to parse out otp fields */
-    if (!strncasecmp(user_entry.secret, "plain:", sizeof("plain:") - 1)) {
-        const char *password = user_entry.secret + sizeof("plain:") - 1;
-        if (vpn_username && !strcmp (vpn_username, user_entry.name)
-            && vpn_secret && password && !strcmp (vpn_secret, password)) {
+        /* Handle non-otp passwords before trying to parse out otp fields */
+        if (!strncasecmp(user_entry.secret, "plain:", sizeof("plain:") - 1)) {
+            const char *password = user_entry.secret + sizeof("plain:") - 1;
+            if (vpn_username && !strcmp (vpn_username, user_entry.name)
+                && vpn_secret && password && !strcmp (vpn_secret, password)) {
         	ok = 1;
+            }
+            goto done;
         }
-        goto done;
-    }
 
-    if (split_secret(user_entry.secret, &otp_params)) {
-        goto done;
-    }
+        if (split_secret(user_entry.secret, &otp_params)) {
+            goto done;
+        }
 
-    otp_digest = EVP_get_digestbyname(otp_params.hash);
-    if (!otp_digest) {
-        LOG("OTP-AUTH: unknown digest '%s'\n", otp_params.hash);
-        goto done;
-    }
+        otp_digest = EVP_get_digestbyname(otp_params.hash);
+        if (!otp_digest) {
+            LOG("OTP-AUTH: unknown digest '%s'\n", otp_params.hash);
+            goto done;
+        }
 
-    unsigned int key_len;
-    const void * otp_key;
+        unsigned int key_len;
+        const void * otp_key;
     
-    if (!strcasecmp(otp_params.encoding, "base32")) {
-        key_len = base32_decode((uint8_t *) otp_params.key, decoded_secret, sizeof(decoded_secret)); 
-        otp_key = decoded_secret;
-    } else
-    if (!strcasecmp(otp_params.encoding, "hex")) {
-	key_len = hex_decode(otp_params.key, decoded_secret, sizeof(decoded_secret));
-	otp_key = decoded_secret;
-    } else
-    if (!strcasecmp(otp_params.encoding, "text")) {
-        otp_key = otp_params.key;
-        key_len = strlen(otp_params.key);
-    } else {
-        LOG("OTP-AUTH: unknown encoding '%s'\n", otp_params.encoding);
-        goto done;
-    }
+        if (!strcasecmp(otp_params.encoding, "base32")) {
+            key_len = base32_decode((uint8_t *) otp_params.key, decoded_secret, sizeof(decoded_secret)); 
+            otp_key = decoded_secret;
+        } else
+            if (!strcasecmp(otp_params.encoding, "hex")) {
+                key_len = hex_decode(otp_params.key, decoded_secret, sizeof(decoded_secret));
+                otp_key = decoded_secret;
+            } else
+                if (!strcasecmp(otp_params.encoding, "text")) {
+                    otp_key = otp_params.key;
+                    key_len = strlen(otp_params.key);
+                } else {
+                    LOG("OTP-AUTH: unknown encoding '%s'\n", otp_params.encoding);
+                    goto done;
+                }
     
-    uint64_t T, Tn;
-    uint8_t mac[EVP_MAX_MD_SIZE];
-    unsigned maclen;
+        uint64_t T, Tn;
+        uint8_t mac[EVP_MAX_MD_SIZE];
+        unsigned maclen;
 
-    if (!strncasecmp("totp", otp_params.method, 4)) {
-        HMAC_CTX hmac;
-        const uint8_t *otp_bytes;
-        uint32_t otp, divisor = 1;
-        int tstep = totp_step;
-        int tdigits = totp_digits;
-        if (!strcasecmp("totp-60-6", otp_params.method)) {
-            tstep = 60;
-            tdigits = 6;
-        }
-        int range = otp_slop / tstep;
+        if (!strncasecmp("totp", otp_params.method, 4)) {
+            HMAC_CTX hmac;
+            const uint8_t *otp_bytes;
+            uint32_t otp, divisor = 1;
+            int tstep = totp_step;
+            int tdigits = totp_digits;
+            if (!strcasecmp("totp-60-6", otp_params.method)) {
+                tstep = 60;
+                tdigits = 6;
+            }
+            int range = otp_slop / tstep;
 
 
-        T = (time(NULL) - totp_t0) / tstep;
+            T = (time(NULL) - totp_t0) / tstep;
 
-        for (i = 0; i < tdigits; ++i) {
-            divisor *= 10;
-        }
+            for (i = 0; i < tdigits; ++i) {
+                divisor *= 10;
+            }
 
-        for (i = -range; !ok && i <= range; ++i) {
-            Tn = htobe64(T + i);
+            for (i = -range; !ok && i <= range; ++i) {
+                Tn = htobe64(T + i);
 
-            HMAC_CTX_init(&hmac);
-            HMAC_Init(&hmac, otp_key, key_len, otp_digest);
-            HMAC_Update(&hmac, (uint8_t *)&Tn, sizeof(Tn));
-            HMAC_Final(&hmac, mac, &maclen);
+                HMAC_CTX_init(&hmac);
+                HMAC_Init(&hmac, otp_key, key_len, otp_digest);
+                HMAC_Update(&hmac, (uint8_t *)&Tn, sizeof(Tn));
+                HMAC_Final(&hmac, mac, &maclen);
 
-            otp_bytes = mac + (mac[maclen - 1] & 0x0f);
-            otp = ((otp_bytes[0] & 0x7f) << 24) | (otp_bytes[1] << 16) |
-                  (otp_bytes[2] << 8) | otp_bytes[3];
-            otp %= divisor;
+                otp_bytes = mac + (mac[maclen - 1] & 0x0f);
+                otp = ((otp_bytes[0] & 0x7f) << 24) | (otp_bytes[1] << 16) |
+                    (otp_bytes[2] << 8) | otp_bytes[3];
+                otp %= divisor;
 
-            snprintf(secret, sizeof(secret), "%s%0*u", otp_params.pin, tdigits, otp);
+                snprintf(secret, sizeof(secret), "%s%0*u", otp_params.pin, tdigits, otp);
 
-            if (vpn_username && !strcmp (vpn_username, user_entry.name)
-                && vpn_secret && !strcmp (vpn_secret, secret)) {
-            	ok = 1;
+                if (vpn_username && !strcmp (vpn_username, user_entry.name)
+                    && vpn_secret && !strcmp (vpn_secret, secret)) {
+                    ok = 1;
+                }
             }
         }
-    }
-    else if (!strcasecmp("motp", otp_params.method)) {
-        char buf[64];
-        int n;
-        int range = otp_slop / motp_step;
+        else if (!strcasecmp("motp", otp_params.method)) {
+            char buf[64];
+            int n;
+            int range = otp_slop / motp_step;
 
-        T = time(NULL) / motp_step;
+            T = time(NULL) / motp_step;
 
-        for (i = -range; !ok && i <= range; ++i) {
-            EVP_MD_CTX ctx;
-            EVP_MD_CTX_init(&ctx);
-            EVP_DigestInit_ex(&ctx, otp_digest, NULL);
-            n = sprintf(buf, "%" PRIu64, T + i);
-            EVP_DigestUpdate(&ctx, buf, n);
-            EVP_DigestUpdate(&ctx, otp_key, key_len);
-            EVP_DigestUpdate(&ctx, otp_params.pin, strlen(otp_params.pin));
-            if (otp_params.udid) {
-                int udid_len = strlen(otp_params.udid);
-                EVP_DigestUpdate(&ctx, otp_params.udid, udid_len);
-            }
-            EVP_DigestFinal_ex(&ctx, mac, &maclen);
-            EVP_MD_CTX_cleanup(&ctx);
+            for (i = -range; !ok && i <= range; ++i) {
+                EVP_MD_CTX ctx;
+                EVP_MD_CTX_init(&ctx);
+                EVP_DigestInit_ex(&ctx, otp_digest, NULL);
+                n = sprintf(buf, "%" PRIu64, T + i);
+                EVP_DigestUpdate(&ctx, buf, n);
+                EVP_DigestUpdate(&ctx, otp_key, key_len);
+                EVP_DigestUpdate(&ctx, otp_params.pin, strlen(otp_params.pin));
+                if (otp_params.udid) {
+                    int udid_len = strlen(otp_params.udid);
+                    EVP_DigestUpdate(&ctx, otp_params.udid, udid_len);
+                }
+                EVP_DigestFinal_ex(&ctx, mac, &maclen);
+                EVP_MD_CTX_cleanup(&ctx);
 
-            snprintf(secret, sizeof(secret),
-                    "%02x%02x%02x", mac[0], mac[1], mac[2]);
+                snprintf(secret, sizeof(secret),
+                         "%02x%02x%02x", mac[0], mac[1], mac[2]);
 
-            if (vpn_username && !strcmp (vpn_username, user_entry.name)
-                && vpn_secret && !strcmp (vpn_secret, secret)) {
-            	ok = 1;
+                if (vpn_username && !strcmp (vpn_username, user_entry.name)
+                    && vpn_secret && !strcmp (vpn_secret, secret)) {
+                    ok = 1;
+                }
             }
         }
-    }
-    else {
-        LOG("OTP-AUTH: unknown OTP method %s\n", otp_params.method);
-    }
+        else {
+            LOG("OTP-AUTH: unknown OTP method %s\n", otp_params.method);
+        }
 
-done:
-    memset(secret, 0, sizeof(secret));
+    done:
+        memset(secret, 0, sizeof(secret));
+
+    }
 
     if (NULL != secrets_file) {
         fclose(secrets_file);


### PR DESCRIPTION
This pull request implements support for [HMAC based One Time Password (hotp)](https://tools.ietf.org/html/rfc4226)

HOTP tokens needs to store the value of the current counter somewhere, in order to keep in sync with the client. As stated in the README; for each HOTP entry in the ``otp-secrets`` files, we compute the sha1 checksum of the secret key, and we use the result as the filename.

The diff is huge because this pull request is built on top of #6. Together, these two features allows an administrator to create backups codes for users, by precomputing them and using a small counter value.
