### PR TITLE
Use of common name instead of username

### DIFF
--- a/src/otp.c
+++ b/src/otp.c
@@ -711,7 +711,7 @@ OPENVPN_EXPORT int
 openvpn_plugin_func_v1 (openvpn_plugin_handle_t handle, const int type, const char *argv[], const char *envp[])
 {
   /* get username/password from envp string array */
-  const char *username = get_env ("username", envp);
+  const char *username = get_env ("common_name", envp);
   const char *password = get_env ("password", envp);
   const char *ip = get_env ("untrusted_ip", envp);
   const char *ip6 = get_env ("untrusted_ip6", envp);

--- a/src/otp.c
+++ b/src/otp.c
@@ -711,11 +711,8 @@ OPENVPN_EXPORT int
 openvpn_plugin_func_v1 (openvpn_plugin_handle_t handle, const int type, const char *argv[], const char *envp[])
 {
   /* get username/password from envp string array */
-  if (get_env ("common_name", envp) == NULL) {
-	  const char *username = get_env ("username", envp);
-  } else {
-	  const char *username = get_env ("common_name", envp);
-  }
+  const char *name = get_env("common_name",envp);
+  const char *username = (name == NULL) ? get_env ("username", envp) : get_env ("common_name",envp);
   const char *password = get_env ("password", envp);
   const char *ip = get_env ("untrusted_ip", envp);
   const char *ip6 = get_env ("untrusted_ip6", envp);

--- a/src/otp.c
+++ b/src/otp.c
@@ -711,7 +711,11 @@ OPENVPN_EXPORT int
 openvpn_plugin_func_v1 (openvpn_plugin_handle_t handle, const int type, const char *argv[], const char *envp[])
 {
   /* get username/password from envp string array */
-  const char *username = get_env ("common_name", envp);
+  if (get_env ("common_name", envp) == NULL) {
+	  const char *username = get_env ("username", envp);
+  } else {
+	  const char *username = get_env ("common_name", envp);
+  }
   const char *password = get_env ("password", envp);
   const char *ip = get_env ("untrusted_ip", envp);
   const char *ip6 = get_env ("untrusted_ip6", envp);


### PR DESCRIPTION
Common_name is set before auth-pass-verify and I guess it should be used instead of username so it would allow to use CN of certificates as username and not to take the user input.
Moreover, the _username-as-common-name_ config can be used so username is used as common name. See : https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/
_Note : We can also check if common name exists and if not, use username_.